### PR TITLE
Fix function return type replay

### DIFF
--- a/complicatedLib.js
+++ b/complicatedLib.js
@@ -1,8 +1,12 @@
-module.exports={
-    a:3,
-    b:function(a,b){
+module.exports = {
+    a: 3,
+    b: function(a,b) {
         "use strict";
         return a*b;
+    },
+    c: function() {
+        "use strict";
+        return new Date('2000-01-01');
     }
 }
 console.log("#".repeat(34));

--- a/spec/example.spec.js
+++ b/spec/example.spec.js
@@ -6,16 +6,19 @@ var objectUnderTest = {
     b: function (complicatedLib) {
         "use strict";
         return complicatedLib.b(10, 10);
+    },
+    c: function (complicatedLib) {
+        "use strict";
+        return complicatedLib.c();
     }
 }
 
 
-xdescribe("simple object using 'complicated' lib", function () {
+describe("simple object using 'complicated' lib", function () {
     var mockRecorder = require('../index.js');
-    var complicatedLib = mockRecorder.wrapper('record', 'my-complicated-lib-which-is-not-part-of-this-test', function () {
+    var complicatedLib = mockRecorder.wrapper('replay', 'my-complicated-lib-which-is-not-part-of-this-test', function () {
         return require('../complicatedLib.js');
     });
-
 
     it("should return 30 on a()", function () {
         expect(objectUnderTest.a(complicatedLib)).toBe(30);
@@ -25,7 +28,9 @@ xdescribe("simple object using 'complicated' lib", function () {
         expect(objectUnderTest.b(complicatedLib)).toBe(100);
     });
 
-    afterEach(mockRecorder.saveWrapper)
+    it("should return a Date on c()", function () {
+        expect(objectUnderTest.c(complicatedLib)).toEqual(new Date("2000-01-01"));
+    });
 
+    afterEach(mockRecorder.saveWrapper);
 });
-

--- a/spec/example.spec.js
+++ b/spec/example.spec.js
@@ -14,7 +14,7 @@ var objectUnderTest = {
 }
 
 
-describe("simple object using 'complicated' lib", function () {
+xdescribe("simple object using 'complicated' lib", function () {
     var mockRecorder = require('../index.js');
     var complicatedLib = mockRecorder.wrapper('replay', 'my-complicated-lib-which-is-not-part-of-this-test', function () {
         return require('../complicatedLib.js');

--- a/spec/example.spec.js
+++ b/spec/example.spec.js
@@ -15,14 +15,14 @@ var objectUnderTest = {
 
 describe("simple object using 'complicated' lib", function () {
     var mockRecorder = require('../index.js');
-    var complicatedLib = mockRecorder.wrapper('replay', 'my-complicated-lib-which-is-not-part-of-this-test', function () {
+    var complicatedLib = mockRecorder.wrapper('record', 'my-complicated-lib-which-is-not-part-of-this-test', function () {
         return require('../complicatedLib.js');
     });
 
     it("should return 30 on a()", function () {
         expect(objectUnderTest.a(complicatedLib)).toBe(30);
     });
-    
+
     it("should return 100 on b()", function () {
         expect(objectUnderTest.b(complicatedLib)).toBe(100);
     });

--- a/spec/foo/bar/baz/mockRecorder.spec.js
+++ b/spec/foo/bar/baz/mockRecorder.spec.js
@@ -38,9 +38,8 @@ describe("mockrecorder", function () {
     it("should get the long storagePath right",function(){
         var expectedPath=__filename.replace(/\\/g,'/').replace('/spec/','/mockStorage/').replace(/\.js$/,'.json');
 
-
         expect(mockRecorder.getStoragePath()).toBe(expectedPath);
     })
 });
-//'/Volumes/external/git/mock-recorder/mockStorage/foo/bar/baz/mockRecorder.spec.json' to be 
+//'/Volumes/external/git/mock-recorder/mockStorage/foo/bar/baz/mockRecorder.spec.json' to be
 //'/Volumes/external/git/mock-recorder/mockStorage/example.spec.json'.

--- a/spec/mockRecorder.spec.js
+++ b/spec/mockRecorder.spec.js
@@ -10,6 +10,9 @@ var objectToMock = {
     function_call: function (a, b) {
         return a + b
     },
+    function_date: function () {
+        return new Date("2000-01-01")
+    },
     booleanTrue: true,
     booleanFalse: false,
     undef_set: undefined,
@@ -24,7 +27,6 @@ var objectToMock = {
         nestedObj: {nestedNestedNumber: 1},
         nestedArray: [1, 2, {nestception: 33}],
         nestedArrayWithObjGet: [1, 2, {nestception: 33}]
-
     },
     arrayInArrayInArray: [[[]]],
     unrecorded: "Unrecorded values won't be part of the mock-replay",
@@ -41,7 +43,7 @@ describe("mockrecorder", function () {
         expect(recorder.d).toEqual(new Date("2000-01-01"))
     });
     it("should proxy Object.keys()", function () {
-        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d']);
+        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'function_date', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d']);
     });
     it("should proxy null", function () {
         expect(recorder.null).toBe(null);
@@ -61,6 +63,10 @@ describe("mockrecorder", function () {
     });
     it("should proxy a function thats callable", function () {
         expect(recorder.function_call(2, 1)).toBe(3)
+    });
+    it("should proxy a function with the correct return-type", function () {
+        expect(recorder.function_date()).toEqual(new Date('2000-01-01'))
+        expect(recorder.function_date() instanceof Date).toBe(true)
     });
     it("should proxy undefined values", function () {
         expect(recorder.undef_set).toBeUndefined()
@@ -84,7 +90,7 @@ describe("mockrecorder", function () {
         expect(recorder.obj.nestedObj.nestedNestedNumber).toBe(1);
     });
     it("should proxy Object.keys()", function () {
-        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d']);
+        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'function_date', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d']);
     });
 
 
@@ -113,6 +119,11 @@ describe("mockrecorder", function () {
     it("should replay a function that's callable and recorded", function () {
         var replay = mockRecorder.replay('test');
         expect(replay.function_call(2, 1)).toBe(3)
+    });
+    it("should replay a function with the correct return-type", function () {
+        var replay = mockRecorder.replay('test');
+        expect(replay.function_date()).toEqual(new Date('2000-01-01'))
+        expect(replay.function_date() instanceof Date).toBe(true)
     });
 
     it("should fail for unrecorded function calls", function () {


### PR DESCRIPTION
The schema for records of returned function-values is now extended. It has been the JSON-stringified schema, but that messed up Dates while not deserializing properly.
Thus, the schema now is changed to {type: 'Date', value: ...} in case of Date-Objects, others have got the type "other" (might be renamed). Other type-(de-)serialization-rules are easy to add.
