### PR TITLE
Feature/increase date precision

### DIFF
--- a/complicatedLib.js
+++ b/complicatedLib.js
@@ -7,6 +7,10 @@ module.exports = {
     c: function() {
         "use strict";
         return new Date('2000-01-01');
+    },
+    d: function() {
+      "use strict";
+      return new Date('2018-10-29T15:24:01.123Z');
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var typeSerializer = function (val) {
 
   switch (type) {
     case 'Date':
-      ret.value = val.toString();
+      ret.value = val.toISOString();
       break;
     default:
       ret.value = val;

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ module.exports.wrapper = function (mode, dependencyName, dependencyCallback) {
     storagePath = getStoragePath();
     return recorder(dependencyCallback(), dependencyName);
   } else {
-    throw new Error("mode should me either record or replay");
+    throw new Error("mode should be either record or replay");
   }
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clover": "node ./node_modules/.bin/istanbul cover --report clover -x \"**/spec/**\" jasmine-node spec/"
   },
   "author": "Dirk Heilig",
-  "contrributors":[
+  "contributors":[
     "Dennis Marschner"
   ],
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clover": "node ./node_modules/.bin/istanbul cover --report clover -x \"**/spec/**\" jasmine-node spec/"
   },
   "author": "Dirk Heilig",
-  "contributors":[
+  "contributors": [
     "Dennis Marschner"
   ],
   "license": "ISC",

--- a/spec/example.spec.js
+++ b/spec/example.spec.js
@@ -10,6 +10,10 @@ var objectUnderTest = {
   c: function (complicatedLib) {
     "use strict";
     return complicatedLib.c();
+  },
+  d: function (complicatedLib) {
+    "use strict";
+    return complicatedLib.d();
   }
 };
 
@@ -29,6 +33,10 @@ describe("simple object using 'complicated' lib record mode", function () {
 
   it("should return a Date on c()", function () {
     expect(objectUnderTest.c(complicatedLib)).toEqual(new Date("2000-01-01"));
+  });
+
+  it("should return a millisecond-accurate Date on d()", function () {
+    expect(objectUnderTest.d(complicatedLib)).toEqual(new Date("2018-10-29T15:24:01.123Z"));
   });
 
   afterEach(mockRecorder.saveWrapper);
@@ -55,6 +63,10 @@ describe("simple object using 'complicated' lib replay mode", function () {
 
   it("should return a Date on c()", function () {
     expect(objectUnderTest.c(complicatedLib)).toEqual(new Date("2000-01-01"));
+  });
+
+  it("should return a millisecond-accurate Date on d()", function () {
+    expect(objectUnderTest.d(complicatedLib)).toEqual(new Date("2018-10-29T15:24:01.123Z"));
   });
 
   afterEach(mockRecorder.saveWrapper);

--- a/spec/mockRecorder.spec.js
+++ b/spec/mockRecorder.spec.js
@@ -29,17 +29,21 @@ var objectToMock = {
     },
     arrayInArrayInArray: [[[]]],
     unrecorded: "Unrecorded values won't be part of the mock-replay",
-    d: new Date("2000-01-01")
+    d: new Date("2000-01-01"),
+    dt: new Date("2018-10-29T15:24:01.123Z")
 };
 
 describe("mockrecorder", function () {
     var recorder = mockRecorder.recorder(objectToMock, 'test');
 
     it("should proxy dateObjects", function () {
-        expect(recorder.d).toEqual(new Date("2000-01-01"))
+      expect(recorder.d).toEqual(new Date("2000-01-01"));
+    });
+    it("should proxy millisecond-accurate dateObjects", function () {
+      expect(recorder.dt).toEqual(new Date("2018-10-29T15:24:01.123Z"));
     });
     it("should proxy Object.keys()", function () {
-        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'function_date', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d']);
+        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'function_date', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded', 'd', 'dt']);
     });
     it("should proxy null", function () {
         expect(recorder.null).toBe(null);
@@ -86,7 +90,7 @@ describe("mockrecorder", function () {
         expect(recorder.obj.nestedObj.nestedNestedNumber).toBe(1);
     });
     it("should proxy Object.keys()", function () {
-        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'function_date', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d']);
+        expect(Object.keys(recorder)).toEqual(['null', 'number', 'string', 'function_get', 'function_call', 'function_date', 'booleanTrue', 'booleanFalse', 'undef_set', 'NaN', 'array', 'obj', 'arrayInArrayInArray', 'unrecorded','d', 'dt']);
     });
 
 
@@ -173,7 +177,7 @@ describe("mockrecorder", function () {
     })
     it("should import  recordings", function () {
         mockRecorder.clearRecordings();
-        mockRecorder.setRecordings({import: {a: {type: 'scalar', value: 2}, d: {type: "date", value: "1999-01-01"}}});
+        mockRecorder.setRecordings({import: {a: {type: 'scalar', value: 2}, d: {type: "date", value: "1999-01-01"}, dt: {type: "date", value: "2018-10-29T15:24:01.123Z"}}});
         expect(mockRecorder.replay('import').a).toBe(2)
     })
     it("should proxy Object.getOwnPropertyDescriptor()", function () {
@@ -184,8 +188,11 @@ describe("mockrecorder", function () {
     it("should handle date-objects correctly", function () {
         expect(mockRecorder.replay('import').d).toEqual(new Date("1999-01-01"))
     })
+    it("should handle millisecond-accurate date-objects correctly", function () {
+      expect(mockRecorder.replay('import').dt).toEqual(new Date("2018-10-29T15:24:01.123Z"))
+    })
 
     it("shout throw on malformed mode", function () {
-        expect(function(){mockRecorder.wrapper("invalid")}).toThrow(new Error("mode should me either record or replay"));
+        expect(function(){mockRecorder.wrapper("invalid")}).toThrow(new Error("mode should be either record or replay"));
     })
 });

--- a/spec/support/mocks/example.spec.json
+++ b/spec/support/mocks/example.spec.json
@@ -18,7 +18,19 @@
       "values": {
         "99914b932bd37a50b983c5e7c90ae93b": {
           "type": "Date",
-          "value": "Sat Jan 01 2000 01:00:00 GMT+0100 (CET)"
+          "value": "Sat Jan 01 2000 01:00:00 GMT+0100 (Mitteleuropäische Zeit)"
+        }
+      }
+    },
+    "inspect": {
+      "type": "scalar"
+    },
+    "d": {
+      "type": "function",
+      "values": {
+        "99914b932bd37a50b983c5e7c90ae93b": {
+          "type": "Date",
+          "value": "Mon Oct 29 2018 16:24:01 GMT+0100 (Mitteleuropäische Zeit)"
         }
       }
     }

--- a/spec/support/mocks/example.spec.json
+++ b/spec/support/mocks/example.spec.json
@@ -18,19 +18,16 @@
       "values": {
         "99914b932bd37a50b983c5e7c90ae93b": {
           "type": "Date",
-          "value": "Sat Jan 01 2000 01:00:00 GMT+0100 (Mitteleuropäische Zeit)"
+          "value": "2000-01-01T00:00:00.000Z"
         }
       }
-    },
-    "inspect": {
-      "type": "scalar"
     },
     "d": {
       "type": "function",
       "values": {
         "99914b932bd37a50b983c5e7c90ae93b": {
           "type": "Date",
-          "value": "Mon Oct 29 2018 16:24:01 GMT+0100 (Mitteleuropäische Zeit)"
+          "value": "2018-10-29T15:24:01.123Z"
         }
       }
     }


### PR DESCRIPTION
The schema for recorded Date-objects was introduced with my PR #3.
This solution used ```.toString()``` to serialize the dates which dropped the milliseconds-part of it. Thus, recorded Dates do not equal the replayed Dates 99.9% of the time (only in case of 0ms it's equal).

With this PR I faced this issue and switched to ```.toISOString()``` to serialize the milliseconds, too. It's even backwards-compatible, even though it of course cannot restore never serialized millisecond-parts of old recordings.